### PR TITLE
Add support for output in config

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -6,6 +6,7 @@ export interface ICommandConfiguration {
     executable: string;
     parameters?: string;
     startIn?: string;
+    shouldOutput?: boolean;
 }
 
 export class LauncherState {

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -51,7 +51,7 @@ export class Launcher {
         let commands = config.get<Array<cfg.ICommandConfiguration>>("commands", []);
         commands.forEach((cfg: cfg.ICommandConfiguration) => {
             this._commands[cfg.description] = {
-                command: new cmd.Command(cfg.description, cfg.executable, cfg.parameters, this._state),
+                command: new cmd.Command(cfg.description, cfg.executable, cfg.parameters, cfg.output, this._state),
                 startIn: cfg.startIn
             };
         });


### PR DESCRIPTION
If output is specified in user settings, uses an output channel to show the command output. 
