### PR TITLE
Fix error in default preference

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
                     "properties": {
                         "executable": {
                             "type": "string",
-                            "description": "Command executable"
+                            "description": "Command executable",
+                            "default": ""
                         },
                         "parameters": {
                             "type": "string",
@@ -72,6 +73,9 @@
                     "required": [
                         "executable"
                     ],
+                    "default": {
+                        "executable": ""
+                    },
                     "description": "Command to launch terminal. Empty value means using default system terminal."
                 },
                 "launcher.commands": {


### PR DESCRIPTION
Fixing error reported by vscode about executable not define in default preferences
